### PR TITLE
♻️ Refactor controller logic for ID and password recovery

### DIFF
--- a/HARU-service/src/main/java/com/grepp/diary/app/controller/web/auth/AuthController.java
+++ b/HARU-service/src/main/java/com/grepp/diary/app/controller/web/auth/AuthController.java
@@ -138,113 +138,101 @@ public class AuthController {
         return "/member/find-idpw";
     }
 
-
-    @PostMapping("/auth-id")
-    public String sendAuthCodeForId(@RequestParam String email, Model model,RedirectAttributes redirectAttributes,
-        @RequestParam(required = false) String code, HttpSession session) {
-
-        if (code == null || code.isBlank()) {
-            // 1. 이메일 유효성 검사
-            if (!memberService.isValidEmail(email)) {
-                model.addAttribute("error", "유효한 이메일 형식이 아닙니다.");
-                return "member/find-idpw";
-            }
-
-            try {
-                // 2.인증 코드 전송 (세션 처리 포함)
-                authService.generateAndSendCode(email, session, null);
-                model.addAttribute("email", email);
-                model.addAttribute("step", "verify");
-                model.addAttribute("message", "인증번호가 전송되었습니다.");
-                return "member/find-idpw";
-            } catch (CommonException e) {
-                model.addAttribute("error", e.getMessage()); // 사용자에게 오류 메시지 전달
-                return "member/find-idpw";
-            }
-        }
-
-        // 인증번호가 입력된 상태 → 인증번호 검증 단계
-        String sessionCode = (String) session.getAttribute("authCode");
-
-        if (sessionCode != null && sessionCode.equals(code)) {
-            try {
-                String userId = memberService.findUserIdByEmailFromSession(session);
-                model.addAttribute("message", userId);
-                return "member/find-idpw-verification";
-            } catch (CommonException e) {
-                model.addAttribute("error", e.getMessage());
-                model.addAttribute("step", null);
-                return "member/find-idpw";
-            }
-        } else {
-            model.addAttribute("error", "인증번호가 일치하지 않습니다.");
-            model.addAttribute("email", email);
-            model.addAttribute("step", "verify");
-
-            return "member/find-idpw";
-
-        }
-
-    }
-
-
-    @PostMapping("/auth-pw")
-    public String sendAuthCodeForPw(@RequestParam String email,
-        @RequestParam String userId,
-        @RequestParam(required = false) String code,
-        Model model,
+    // 아이디 + 비번 합쳐서 (이메일 유효성)검사 + 인증코드 전송
+    @PostMapping("/auth-idpw")
+    public String sendAuthCodeForId(@RequestParam String email, Model model,
+        @RequestParam(required = false) String userId,
         HttpSession session) {
 
-        if (code == null || code.isBlank()) {
-            // 1. 이메일 형식 확인
-            if (!memberService.isValidEmail(email)) {
-                model.addAttribute("error", "유효한 이메일 형식이 아닙니다.");
+        // code 존재 x = 인증번호 요청 전 단계
+        // 이메일만 입력 들어오면 아이디 검사(아이디 존재x)
+
+        // 아이디+비번 검사 1단계 : 이메일 유효성 검사
+        if (!memberService.isValidEmail(email)) {
+            if (userId != null) {
+                // 비번 검사 1.1 단계
                 model.addAttribute("type", "pw");
-                return "member/find-idpw";
             }
+            model.addAttribute("error", "유효한 이메일 형식이 아닙니다.");
+            return "member/find-idpw";
+        }
 
-            // 2. 이메일 + 아이디로 사용자 존재 확인
-            if (!memberService.existsByUserIdAndEmail(userId, email)) {
-                model.addAttribute("error", "일치하는 계정이 없습니다.");
-                model.addAttribute("type", "pw");
-                return "member/find-idpw";
-            }
-
-            // 3. 인증 코드 생성 및 저장
-            authService.generateAndSendCode(email, session, userId);
-
-
-            model.addAttribute("email", email);
-            model.addAttribute("userId", userId);
-            model.addAttribute("step", "verify");
-            model.addAttribute("message", "인증번호가 전송되었습니다.");
+        // 비번 검사 1.2단계 : 이메일 + 아이디로 사용자 존재 확인
+        if (!memberService.existsByUserIdAndEmail(userId, email)) {
+            model.addAttribute("error", "일치하는 계정이 없습니다.");
             model.addAttribute("type", "pw");
             return "member/find-idpw";
         }
 
-        // 4. 인증번호 확인
+        try {
+            // 아이디 + 비번 검사 2단계 : 인증 코드 전송 (세션 처리 포함)
+            if (userId != null) {
+                // 비번 찾기
+                authService.generateAndSendCode(email, session, userId);
+                model.addAttribute("userId", userId);
+                model.addAttribute("type", "pw");
+            }else {
+                // 아이디찾기
+                authService.generateAndSendCode(email, session, null);
+            }
+            model.addAttribute("email", email);
+            model.addAttribute("step", "verify");
+            model.addAttribute("message", "인증번호가 전송되었습니다.");
+            return "member/find-idpw";
+        } catch (CommonException e) {
+            model.addAttribute("error", e.getMessage()); // 사용자에게 오류 메시지 전달
+            return "member/find-idpw";
+        }
+
+    }
+
+    // 아이디 + 비번 합쳐서 인증 코드 검증
+    @PostMapping("/auth-idpw-verification")
+    public String findIdCodeVerification(@RequestParam String email, Model model,
+        @RequestParam(required = false) String userId,
+        @RequestParam String code, HttpSession session) {
+
+        // 인증번호가 입력된 상태 → 인증번호 검증 단계
         String sessionCode = (String) session.getAttribute("authCode");
         String sessionEmail = (String) session.getAttribute("authEmail");
         String sessionUserId = (String) session.getAttribute("authUserId");
 
+        // 인증 성공!!
         if (sessionCode != null && sessionCode.equals(code)) {
             // 세션 제거
             session.removeAttribute("authCode");
-
-            // 비밀번호 재설정 페이지로 이동
-            model.addAttribute("email", sessionEmail);
-            model.addAttribute("userId", sessionUserId);
+            model.addAttribute("isSuccess", true);
+            if( userId == null) {
+                try {
+                    // 아이디 찾기
+                    userId = memberService.findUserIdByEmailFromSession(session);
+                    model.addAttribute("message", userId);
+                    return "member/find-idpw-verification";
+                } catch (CommonException e) {
+                    model.addAttribute("error", e.getMessage());
+                    model.addAttribute("step", null);
+                    return "member/find-idpw";
+                }
+            } else {
+                // 비번 찾기
+                model.addAttribute("email", sessionEmail);
+                model.addAttribute("userId", sessionUserId);
+                model.addAttribute("step", "verify");
+                return "member/find-idpw-verification";
+            }
+        }else {
+            // 인증 실패!!
+            if (userId != null) {
+                // 비번 찾기
+                model.addAttribute("userId", userId);
+                model.addAttribute("type", "pw");
+            }
+            model.addAttribute("error", "인증번호가 일치하지 않습니다.");
+            model.addAttribute("email", email);
             model.addAttribute("step", "verify");
-
-            return "member/reset-password";
+            model.addAttribute("isSuccess", false);
+            return "member/find-idpw";
         }
-
-        model.addAttribute("error", "인증번호가 일치하지 않습니다.");
-        model.addAttribute("step", "verify");
-        model.addAttribute("email", email);
-        model.addAttribute("userId", userId);
-        model.addAttribute("type", "pw");
-        return "member/find-idpw";
     }
 
     @PostMapping("/change-pw")

--- a/HARU-service/src/main/java/com/grepp/diary/infra/config/SecurityConfig.java
+++ b/HARU-service/src/main/java/com/grepp/diary/infra/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                     .requestMatchers("/admin/**", "/api/admin/**").hasRole("ADMIN")
                     .requestMatchers(GET, "/", "/css/**", "/js/**", "/images/**", "/assets/**", "/uploads/**").permitAll()
                     .requestMatchers("/auth/**").permitAll()
-                    .requestMatchers("/auth/login", "/auth/logout", "/auth/find_id", "/auth/find_pw", "/auth/regist/**", "/auth/regist-mail","/auth/auth-id","/auth/auth-pw").permitAll()
+                    .requestMatchers("/auth/login", "/auth/logout", "/auth-idpw","/auth-idpw-verification", "/auth/regist/**", "/auth/regist-mail","/auth/auth-id","/auth/auth-pw").permitAll()
                     .requestMatchers("/auth/change-pw", "/auth/find-idpw","/member/leave", "/member/leave-success").permitAll()
                     .requestMatchers("/custom/**").permitAll()
                     .requestMatchers("/api/ai/list/img").permitAll()


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
아이디/ 비번 찾기 컨트롤러 리팩토링
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 기존에는 아이디 / 비번 따로 컨트롤러 로직이 존재하였습니다. auth-id / auth-pw => userId로 구분하여 컨트롤러 1개로 합쳤습니다.
- 기존에는 하나의 컨트롤러에서 이메일 유효성 검사 + 이메일 인증코드 발송 + 이메일 인증코드 검사 세가지를 수행하였습니다. => 유효성검사 + 인증코드 발송 / 이메일 인증코드 검사 두개로 컨트롤러를 분리하였습니다. auth-idpw / auth-idpw-verification
- 인증코드 인증이 성공하면 isSuccess란 model에 true/false 값을 담아서 view로 보냅니다.
- security에서 컨트롤러 엔드포인트 추가하였습니다.

