### PR TITLE
Redis 설정 수정

### DIFF
--- a/HARU-service/src/main/java/com/grepp/diary/infra/config/CacheConfig.java
+++ b/HARU-service/src/main/java/com/grepp/diary/infra/config/CacheConfig.java
@@ -1,44 +1,15 @@
 package com.grepp.diary.infra.config;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import java.time.Duration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 @Configuration
 public class CacheConfig {
 
-    /**
-     * Redis 전용 ObjectMapper (전역 등록 아님)
-     */
-    public ObjectMapper redisObjectMapper() {
-        ObjectMapper objectMapper = new ObjectMapper();
-
-        // 기본 타입 활성화 (type id 포함)
-        objectMapper.activateDefaultTyping(
-            BasicPolymorphicTypeValidator.builder()
-                .allowIfBaseType(Object.class)
-                .build(),
-            ObjectMapper.DefaultTyping.EVERYTHING,
-            JsonTypeInfo.As.PROPERTY
-        );
-
-        // Spring Security 타입 대응
-        objectMapper.addMixIn(SimpleGrantedAuthority.class, SimpleGrantedAuthorityMixin.class);
-
-        return objectMapper;
-    }
-
-    /**
-     * Redis 캐시 설정에만 Custom ObjectMapper 사용
-     */
     @Bean
     public RedisCacheConfiguration cacheConfiguration() {
 

--- a/HARU-service/src/main/resources/application.properties
+++ b/HARU-service/src/main/resources/application.properties
@@ -33,7 +33,7 @@ spring.cache.redis.time-to-live=86400000
 
 # jwt
 jwt.secrete=sskfjsasdkfsdklfjwioesdfjslkdfjsdlkfjsdlf
-jwt.access-expiration=3600
+jwt.access-expiration=3600000
 jwt.refresh-expiration=604800000
 
 # redis


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 감정분석 결과를 저장하기 위한 레디스 설정을 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 원인: ObjectMapper 의 JWT 파싱 과정이 감정분석 결과값에도 적용됨 (감정분석 결과값은 단순한 문자열로 파싱이 불필요)
- 단순한 StringRedisSerializer 적용
- 감정분석 결과값이 기본값인 30분으로 저장 -> 24시간 저장으로 변경
